### PR TITLE
php-uv 0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,14 +231,15 @@ workflows:
   tests:
     jobs:
       # pecl builds
-      - php-71
-      - php-71-zts
-      - php-72
-      - php-72-zts
-      - php-73
-      - php-73-zts
-      - php-74
-      - php-74-zts
+      # uncommented due to no release yet
+      # - php-71
+      # - php-71-zts
+      # - php-72
+      # - php-72-zts
+      # - php-73
+      # - php-73-zts
+      # - php-74
+      # - php-74-zts
 
       # git builds
       - php-71-git
@@ -251,5 +252,6 @@ workflows:
       - php-74-zts-git
 
       # windows builds
-      - php-win
-      - php-zts-win
+      # uncommented due to no release yet
+      # - php-win
+      # - php-zts-win

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This library provides libuv child processes for ReactPHP.
 
-Due to underlying ext-uv circumstances, the PID is only available, as of commit [`082fdfb`](https://github.com/bwoebi/php-uv/commit/082fdfb20387af02956a68ba77dfa78e2ae9c5b8), otherwise the PID is `0`.
+Requires php-uv v0.3+.
 
 # Example
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php-64bit": ">=7.1",
-        "ext-uv": "*",
+        "ext-uv": ">=0.3",
         "react/event-loop": "^1.0|^0.5|^0.4",
         "react/promise": "^2.7",
         "react/stream": "^1.0",

--- a/src/Process.php
+++ b/src/Process.php
@@ -60,7 +60,7 @@ class Process implements EventEmitterInterface {
      * @var int
      * @source
      */
-    const DEFAULT_PROCESS_FLAGS_WIN = 16; //\UV::PROCESS_WINDOWS_HIDE;
+    const DEFAULT_PROCESS_FLAGS_WIN = \UV::PROCESS_WINDOWS_HIDE;
     
     /**
      * The maximum timer interval that is allowed.
@@ -365,7 +365,7 @@ class Process implements EventEmitterInterface {
         }
         
         $this->process = $process;
-        $this->pid = (\function_exists('uv_process_get_pid') ? \uv_process_get_pid($process) : 0);
+        $this->pid = \uv_process_get_pid($process);
         
         foreach($this->stdios as $key => $pipe) {
             $pipe = $this->prepareStdio($loop, $pipe, ($this->fdspecs[$key][1] ?? null));

--- a/src/ReadablePipeStream.php
+++ b/src/ReadablePipeStream.php
@@ -103,27 +103,16 @@ class ReadablePipeStream implements ReadableStreamInterface {
         
         \uv_read_start($this->pipe, function (\UVPipe $pipe, $nread) {
             if(\is_string($nread)) {
-                $buffer = $nread;
-                $nread = 1;
-            } else {
-                $buffer = \func_get_args()[2] ?? '';
-            }
-            
-            if($nread === \UV::EOF) {
+                $this->emit('data', array($nread));
+            } elseif($nread === \UV::EOF) {
                 $this->emit('end');
                 $this->close();
-                return;
             } elseif($nread < 0) {
                 $e = new \RuntimeException('Unable to read from pipe: '.\uv_strerror($nread));
                 $this->emit('error', array($e));
                 
                 $this->close();
-                return;
-            } elseif($nread === 0) {
-                return; // @codeCoverageIgnore
             }
-            
-            $this->emit('data', array($buffer));
         });
         
         $this->listening = true;

--- a/tests/ProcessTest.php
+++ b/tests/ProcessTest.php
@@ -251,10 +251,6 @@ class ProcessTest extends TestCase {
      * @runInSeparateProcess
      */
     function testStartInvalidParams() {
-        if(\PHP_ZTS === 1 && \getenv('TYPE', true) !== 'git') {
-            $this->markTestSkipped('Currently only git does not segfault during coverage');
-        }
-        
         $loop = new ExtUvLoop();
         $process = new Process('');
         
@@ -296,11 +292,9 @@ class ProcessTest extends TestCase {
         $this->assertNull($process->getPid());
         
         $process->start($loop);
-        $this->assertNotNull($process->getPid());
         
-        if(\function_exists('uv_process_get_pid')) {
-            $this->assertGreaterThan(0, $process->getPid());
-        }
+        $this->assertNotNull($process->getPid());
+        $this->assertGreaterThan(0, $process->getPid());
     }
     
     /**


### PR DESCRIPTION
**Pull Request description:**
Removes php-uv v0.2 support.

Currently missing: CI pecl and windows builds, since php-uv 0.3 is not released yet.

Resolves #1.

**Why should this Pull Request be merged:**
Less maintenance and less bugs. :)

**Semantic Versioning Classification:**
- [X] This PR includes major breaking changes (such as method changes)
- [ ] This PR includes **only** documentational changes (such as docblocks, README, etc.)
